### PR TITLE
Chore: align tooling and product manifest loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,53 +7,80 @@ Rovewear Shop is a Vite + React + TypeScript storefront starter configured for T
 - Node.js 20.18 LTS (matching the `engines` field)
 - npm 10+
 
+## Installation & Scripts
+
+Install dependencies once:
+
+```bash
+npm install
+```
+
+Available scripts:
+
+- `npm run dev` – start the Vite development server on <http://localhost:5173> for local iteration.
+- `npm run build` – create a production build in `dist/`.
+- `npm run preview` – serve the production build locally to verify before deploying.
+- `npm run lint` – run ESLint across TypeScript and JavaScript sources.
+
+## Product Data & Assets
+
+All storefront products load at runtime from `public/products/products.json`. Each entry must provide:
+
+```json
+{
+  "id": "wayfarer",
+  "name": "Wayfarer Frames",
+  "description": "Classic silhouettes crafted with plant-based acetate...",
+  "price": 185,
+  "image": "/products/wayfarer.svg",
+  "tags": ["best seller", "handcrafted"]
+}
+```
+
+- Add or edit inventory by updating `products.json`.
+- Place matching imagery (SVGs, PNGs, JPEGs, etc.) inside `public/products/` and reference them by their `/products/<file>` path.
+- Runtime fetch errors surface in the UI with a retry button so editors know if the manifest or asset path needs attention.
+
+## Project Structure
+
+```
+├── index.html            # Vite entry document
+├── public/               # Static assets served as-is
+│   └── products/         # JSON manifest + product artwork
+├── src/
+│   ├── App.tsx           # Application shell
+│   ├── components/       # Reusable UI building blocks
+│   ├── data/products.ts  # Typed helpers + manifest loader
+│   └── styles/index.css  # Tailwind entry point + global styles
+├── tailwind.config.ts    # Tailwind v4 configuration
+├── postcss.config.js     # Tailwind/PostCSS plugins
+└── vite.config.ts        # Vite build + dev server settings
+```
+
+## Deployment on Vercel
+
+A `vercel.json` file instructs Vercel to run `npm run build`, serve the `dist/` directory, and rewrite all routes to the SPA entry point. The typical workflow is:
+
+1. Commit changes locally.
+2. Push to GitHub.
+3. Vercel automatically builds a preview deployment for the branch.
+4. Merge or promote the preview to production when it looks good.
+
+No manual ZIP uploads or environment tweaks are required—Vercel picks up the repo as-is.
+
+## Tailwind CSS v4
+
+Tailwind CSS v4 is enabled via the official `@tailwindcss/postcss` plugin. Styles are imported once in `src/styles/index.css`, and `tailwind.config.ts` scans `index.html` plus every component in `src/` to tree-shake unused classes.
+
 ## Clean Reinstall
 
-If dependencies ever drift or you need to start fresh in Codespaces, a local terminal, or another cloud IDE, run these commands in order:
+If dependencies drift or you need to start fresh in Codespaces, a local terminal, or another cloud IDE, run:
 
 ```bash
 rm -rf node_modules package-lock.json
 npm install
 npm run dev
 ```
-
-- `npm run dev` starts the Vite development server on <http://localhost:3000>.
-- `npm run build` bundles the app for production into `dist/`.
-- `npm run preview` serves the built bundle locally for final verification.
-
-## Project Structure
-
-```
-├── index.html            # Vite entry document
-├── public/               # Static assets (placeholder product imagery)
-├── public/
-│   └── products/
-│       ├── products.json # Placeholder inventory served with the built site
-│       └── *.svg         # Product illustrations referenced by components
-├── src/
-│   ├── App.tsx           # Application shell
-│   ├── components/       # Reusable UI building blocks
-│   ├── data/products.ts  # Typed helpers for the JSON manifest
-│   └── styles/index.css  # Tailwind entry point + global styles
-├── tailwind.config.ts    # Tailwind v4 configuration
-└── vite.config.ts        # Vite build + dev server settings
-```
-
-The `public/products/` directory retains the placeholder imagery and the `products.json` manifest consumed by the storefront. Components load this static JSON file at runtime, so you can swap in a CMS, REST API, or e-commerce SDK later without rewriting UI components.
-
-## Deployment
-
-The included `vercel.json` configures Vercel to run `npm run build` (which maps to `vite build`) and serve the `dist/` directory. A single-page-app fallback ensures direct URL visits resolve correctly after client-side routing is introduced.
-
-Pushes to `main` (or any branch connected to Vercel) trigger automatic builds—no manual uploads or file copies are required.
-
-## Tailwind CSS v4
-
-Tailwind CSS v4 is enabled through the `@tailwindcss/postcss` plugin. Styles are imported once in `src/styles/index.css`, and the `content` array in `tailwind.config.ts` scans the Vite entry document plus every component in `src/` to tree-shake unused classes.
-
-## Codespaces / Devcontainers
-
-A `.devcontainer/devcontainer.json` file pins the Node.js version and recommends VS Code extensions so you can open the project remotely with consistent tooling.
 
 ## Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "rovewear-shop",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "engines": {
     "node": "^20.18.0"
   },
@@ -9,7 +10,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0"
+    "lint": "eslint . --ext .ts,.tsx,.js,.jsx"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     "@tailwindcss/postcss": {},
     autoprefixer: {},

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
       colors: {

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,5 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
-  ]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
## Summary
- switch the project to native ESM, update npm scripts, and adopt the official @tailwindcss/postcss pipeline
- tighten Tailwind content scanning, refresh Vercel rewrites, and document deployment plus product manifest editing in the README
- harden product loading with abort-safe retries and user-facing error messaging sourced from the public JSON manifest

## Testing
- `npm run build`
- `npm run lint` *(fails: missing @typescript-eslint packages because npm install is blocked by registry 403 in the container)*
- `timeout 5 npm run dev -- --host 0.0.0.0 --port 5173`
- `npm install` *(fails: registry 403 prevents downloading dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a2e5d968832f8d2f7ed1c626a219