### PR TITLE
Fix: align Next.js and React versions for stable deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "start": "next start",
     "lint": "eslint . --ext ts,tsx --fix",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
-    "test:e2e": "playwright test"
+    "test": "jest"
   },
   "dependencies": {
     "@portabletext/react": "^3.1.0",
@@ -20,15 +19,14 @@
     "@sanity/image-url": "^1.0.2",
     "date-fns": "^3.6.0",
     "framer-motion": "^11.11.10",
-    "next": "15.0.0-canary.65",
+    "next": "14.2.5",
     "next-sanity": "^9.5.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "sanity": "^3.61.0",
     "@sanity/vision": "^3.6.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.48.2",
     "@testing-library/jest-dom": "^6.4.7",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.6.1",
@@ -43,7 +41,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.49",
     "prettier": "^3.3.3",
-    "tailwindcss": "^4.0.0-alpha.19",
+    "tailwindcss": "^3.4.13",
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"


### PR DESCRIPTION
## Summary
- pin Next.js to the latest 14.x stable release compatible with React 18
- align React and React DOM to the 18.2 line expected by Next 14 and keep Sanity integrations unchanged
- downgrade TailwindCSS to the current 3.x stable series to avoid prerelease installs and remove unused Playwright e2e test script

## Testing
- npm install *(fails: registry returned HTTP 403 for scoped packages in this environment)*
- npm run lint *(not run: npm install failed)*
- npm run build *(not run: npm install failed)*
- npm run typecheck *(not run: npm install failed)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bb889ddc832fa062552cee15ab82