### PR TITLE
Chore: add styled-components deps and clean Next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  typedRoutes: true,
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "next-sanity": "^11.1.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "sanity": "^3.61.0"
+    "sanity": "^3.61.0",
+    "styled-components": "^6.1.8"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.2",
@@ -48,6 +49,7 @@
     "tailwindcss": "^4.1.13",
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "@types/styled-components": "^5.1.34"
   }
 }


### PR DESCRIPTION
## Summary
- add styled-components runtime dependency and its TypeScript typings to support styling updates
- drop the deprecated typedRoutes flag from the Next.js configuration to remove build warnings

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d0cdb832fc832f9f5fb48c1468aa45